### PR TITLE
feat: prevent duplicate names in phonebook

### DIFF
--- a/part2/phonebook/src/App.jsx
+++ b/part2/phonebook/src/App.jsx
@@ -12,9 +12,15 @@ const App = () => {
     };
 
     //console.log(personObject);
+    //console.log(persons.findIndex((el) => el.name === personObject.name));
 
-    setPersons(persons.concat(personObject));
-    setNewName("");
+    const index = persons.findIndex((el) => el.name === personObject.name);
+    if (index != -1) {
+      alert(`${personObject.name} is already added to phonebook`);
+    } else {
+      setPersons(persons.concat(personObject));
+      setNewName("");
+    }
   };
 
   const handlePersonChange = (e) => {


### PR DESCRIPTION
- Implemented a check to prevent adding duplicate names
- Used `find()` to verify if a name already exists in the list
- Displayed an alert when a user tries to add an existing name