### PR TITLE
fix: preserve user info when updating blog likes

### DIFF
--- a/part5/blogs-backend/controllers/blogs.js
+++ b/part5/blogs-backend/controllers/blogs.js
@@ -58,7 +58,7 @@ blogsRouter.put("/:id", async (request, response, next) => {
       request.params.id,
       { likes },
       { new: true, runValidators: true, context: "query" }
-    );
+    ).populate("user", { username: 1, name: 1 });
 
     if (updatedBlog) {
       response.json(updatedBlog);


### PR DESCRIPTION
Ensures that the user information (username and name) is returned when updating a blog's likes in the backend. Adds populate("user", { username: 1, name: 1 }) to findByIdAndUpdate so the frontend continues to receive the author details after a like increment.