### PR TITLE
feat: sort blogs by number of likes

### DIFF
--- a/part5/bloglist-frontend-main/src/App.jsx
+++ b/part5/bloglist-frontend-main/src/App.jsx
@@ -138,9 +138,11 @@ const App = () => {
 
           <hr />
 
-          {blogs.map((blog) => (
-            <Blog key={blog.id} blog={blog} handleLike={handleLike} />
-          ))}
+          {[...blogs]
+            .sort((a, b) => b.likes - a.likes)
+            .map((blog) => (
+              <Blog key={blog.id} blog={blog} handleLike={handleLike} />
+            ))}
           <hr />
           <button onClick={handleLogout}>log-out</button>
         </div>


### PR DESCRIPTION
Changes the display order of blogs in the frontend to be sorted by likes in descending order. Uses array sort in combination with map to render blogs in the new order.