### PR TITLE
test: like button calls handler twice

### DIFF
--- a/part5/bloglist-frontend-main/src/components/Blog.test.jsx
+++ b/part5/bloglist-frontend-main/src/components/Blog.test.jsx
@@ -37,4 +37,19 @@ describe("<Blog />", () => {
     expect(screen.getByText("http://example.com")).toBeDefined();
     expect(screen.getByText("likes 10")).toBeDefined();
   });
+
+  test("calls event handler twice if like button is clicked twice", async () => {
+    const mockHandler = vi.fn();
+    render(<Blog blog={blog} handleLike={mockHandler} user={blog.user} />);
+    const userSetup = userEvent.setup();
+
+    const viewButton = screen.getByText("view");
+    await userSetup.click(viewButton);
+
+    const likeButton = screen.getByText("like");
+    await userSetup.click(likeButton);
+    await userSetup.click(likeButton);
+
+    expect(mockHandler).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Added a test in Blog.test.jsx to verify that clicking the "like" button twice calls the event handler passed as a prop two times.