### PR TITLE
refactor: extract action creators to anecdoteReducer module

### DIFF
--- a/part6/redux-anecdotes-main/src/App.jsx
+++ b/part6/redux-anecdotes-main/src/App.jsx
@@ -1,18 +1,19 @@
 import { useSelector, useDispatch } from "react-redux";
+import { voteAnecdote, createAnecdote } from "./reducers/anecdoteReducer";
 
 const App = () => {
   const anecdotes = useSelector((state) => state);
   const dispatch = useDispatch();
 
   const vote = (id) => {
-    dispatch({ type: "VOTE", payload: { id } });
+    dispatch(voteAnecdote(id));
   };
 
   const addAnecdote = (event) => {
     event.preventDefault();
     const content = event.target.anecdote.value;
     event.target.anecdote.value = "";
-    dispatch({ type: "NEW_ANECDOTE", payload: content });
+    dispatch(createAnecdote(content));
   };
 
   const sortedAnecdotes = [...anecdotes].sort((a, b) => b.votes - a.votes);
@@ -20,7 +21,6 @@ const App = () => {
   return (
     <div>
       <h2>Anecdotes</h2>
-      {}
       {sortedAnecdotes.map((anecdote) => (
         <div key={anecdote.id}>
           <div>{anecdote.content}</div>

--- a/part6/redux-anecdotes-main/src/reducers/anecdoteReducer.js
+++ b/part6/redux-anecdotes-main/src/reducers/anecdoteReducer.js
@@ -20,7 +20,7 @@ const asObject = (anecdote) => {
 
 const initialState = anecdotesAtStart.map(asObject);
 
-const reducer = (state = initialState, action) => {
+const anecdoteReducer = (state = initialState, action) => {
   console.log("state now: ", state);
   console.log("action", action);
 
@@ -37,11 +37,25 @@ const reducer = (state = initialState, action) => {
       );
     case "NEW_ANECDOTE":
       const newAnecdote = asObject(action.payload);
-
       return state.concat(newAnecdote);
     default:
       return state;
   }
 };
 
-export default reducer;
+// Action creators
+export const voteAnecdote = (id) => {
+  return {
+    type: "VOTE",
+    payload: { id },
+  };
+};
+
+export const createAnecdote = (content) => {
+  return {
+    type: "NEW_ANECDOTE",
+    payload: content,
+  };
+};
+
+export default anecdoteReducer;


### PR DESCRIPTION
Moved action creation logic for voting and new anecdotes into dedicated action creator functions in anecdoteReducer.js. Updated App.jsx to use these functions instead of dispatching actions directly. This improves code organization, reduces duplication, and aligns with Redux best practices by centralizing action logic.