### PR TITLE
refactor: extract anecdote creation into separate AnecdoteForm component

### DIFF
--- a/part6/redux-anecdotes-main/src/App.jsx
+++ b/part6/redux-anecdotes-main/src/App.jsx
@@ -1,5 +1,6 @@
 import { useSelector, useDispatch } from "react-redux";
-import { voteAnecdote, createAnecdote } from "./reducers/anecdoteReducer";
+import { voteAnecdote } from "./reducers/anecdoteReducer";
+import AnecdoteForm from "./components/AnecdoteForm";
 
 const App = () => {
   const anecdotes = useSelector((state) => state);
@@ -7,13 +8,6 @@ const App = () => {
 
   const vote = (id) => {
     dispatch(voteAnecdote(id));
-  };
-
-  const addAnecdote = (event) => {
-    event.preventDefault();
-    const content = event.target.anecdote.value;
-    event.target.anecdote.value = "";
-    dispatch(createAnecdote(content));
   };
 
   const sortedAnecdotes = [...anecdotes].sort((a, b) => b.votes - a.votes);
@@ -30,13 +24,7 @@ const App = () => {
           </div>
         </div>
       ))}
-      <h2>create new</h2>
-      <form onSubmit={addAnecdote}>
-        <div>
-          <input name="anecdote" />
-        </div>
-        <button type="submit">create</button>
-      </form>
+      <AnecdoteForm />
     </div>
   );
 };

--- a/part6/redux-anecdotes-main/src/components/AnecdoteForm.js
+++ b/part6/redux-anecdotes-main/src/components/AnecdoteForm.js
@@ -1,0 +1,27 @@
+import { useDispatch } from "react-redux";
+import { createAnecdote } from "../reducers/anecdoteReducer";
+
+const AnecdoteForm = () => {
+  const dispatch = useDispatch();
+
+  const addAnecdote = (event) => {
+    event.preventDefault();
+    const content = event.target.anecdote.value;
+    event.target.anecdote.value = "";
+    dispatch(createAnecdote(content));
+  };
+
+  return (
+    <div>
+      <h2>create new</h2>
+      <form onSubmit={addAnecdote}>
+        <div>
+          <input name="anecdote" />
+        </div>
+        <button type="submit">create</button>
+      </form>
+    </div>
+  );
+};
+
+export default AnecdoteForm;


### PR DESCRIPTION
Moved anecdote creation form and logic from App.jsx to a dedicated AnecdoteForm component. This improves modularity and adheres to the single responsibility principle by separating concerns. App.jsx now focuses solely on displaying anecdotes and handling votes, while AnecdoteForm manages anecdote creation using the createAnecdote action creator.