### PR TITLE
refactor: extract anecdote list and voting into AnecdoteList component

### DIFF
--- a/part6/redux-anecdotes-main/src/App.jsx
+++ b/part6/redux-anecdotes-main/src/App.jsx
@@ -1,29 +1,11 @@
-import { useSelector, useDispatch } from "react-redux";
-import { voteAnecdote } from "./reducers/anecdoteReducer";
 import AnecdoteForm from "./components/AnecdoteForm";
+import AnecdoteList from "./components/AnecdoteList";
 
 const App = () => {
-  const anecdotes = useSelector((state) => state);
-  const dispatch = useDispatch();
-
-  const vote = (id) => {
-    dispatch(voteAnecdote(id));
-  };
-
-  const sortedAnecdotes = [...anecdotes].sort((a, b) => b.votes - a.votes);
-
   return (
     <div>
       <h2>Anecdotes</h2>
-      {sortedAnecdotes.map((anecdote) => (
-        <div key={anecdote.id}>
-          <div>{anecdote.content}</div>
-          <div>
-            has {anecdote.votes}
-            <button onClick={() => vote(anecdote.id)}>vote</button>
-          </div>
-        </div>
-      ))}
+      <AnecdoteList />
       <AnecdoteForm />
     </div>
   );

--- a/part6/redux-anecdotes-main/src/components/AnecdoteList.js
+++ b/part6/redux-anecdotes-main/src/components/AnecdoteList.js
@@ -1,0 +1,29 @@
+import { useSelector, useDispatch } from "react-redux";
+import { voteAnecdote } from "../reducers/anecdoteReducer";
+
+const AnecdoteList = () => {
+  const anecdotes = useSelector((state) => state);
+  const dispatch = useDispatch();
+
+  const vote = (id) => {
+    dispatch(voteAnecdote(id));
+  };
+
+  const sortedAnecdotes = [...anecdotes].sort((a, b) => b.votes - a.votes);
+
+  return (
+    <div>
+      {sortedAnecdotes.map((anecdote) => (
+        <div key={anecdote.id}>
+          <div>{anecdote.content}</div>
+          <div>
+            has {anecdote.votes}
+            <button onClick={() => vote(anecdote.id)}>vote</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default AnecdoteList;


### PR DESCRIPTION
Moved anecdote listing and voting logic from App.jsx to a dedicated AnecdoteList component. This improves modularity and separation of concerns, following the presentational/container pattern. App.jsx now acts as a clean container that composes AnecdoteForm and AnecdoteList, making the code more testable and maintainable.